### PR TITLE
Fixes issue where fdset types cant resolve

### DIFF
--- a/src/wasi/wasix.rs
+++ b/src/wasi/wasix.rs
@@ -269,7 +269,7 @@ s! {
 
     pub struct fd_set {
         __nfds: usize,
-        __fds: [c_int; FD_SETSIZE as usize],
+        __fds: [::c_int; ::FD_SETSIZE as usize],
     }
 
     pub struct termios {


### PR DESCRIPTION
<!--
Thanks for considering submitting a PR!

We have the
[contribution guide](https://github.com/rust-lang/libc/blob/main/CONTRIBUTING.md).
Please read it if you're new here!

Here is a checklist for things that will be checked during review or continuous
integration:

- \[x] Edit corresponding file(s) under `libc-test/semver` when you add/remove
  item(s), e.g. edit `linux.txt` if you add an item to
  `src/unix/linux_like/linux/mod.rs`
- \[x] Your PR doesn't contain any private or _unstable_ values like `*LAST` or
  `*MAX` (see [#3131](https://github.com/rust-lang/libc/issues/3131))
- \[x] Provide a link to relevant source (headers or documentation) if your PR
  adds or changes API.
- \[x] If your PR has a breaking change, please clarify it
- \[x] If your PR increments version number, it must NOT contain any other
  changes (otherwise a release could be delayed)
- \[x] Make sure `ci/style.sh` passes
- \[x] `cd libc-test && cargo test`
  - (this might fail on your env due to environment difference between your env
    and CI. Ignore local failures if you are not sure)

Delete this line and everything above before opening your PR.
-->
After cleaning up a [sample rust app](https://github.com/TheNotary/another-rust-terminal-app) I've been testing with wasmer, I discovered on the latest version/ branch, the struct for `fd_set` was throwing errors.  It seems that they didn't have the absolute namespace pathing (e.g. `::c_int`) and instead were written as `c_int`.  

Error:

> $ cargo wasix run
...
error[E0412]: cannot find type `c_int` in this scope
   --> /libc/src/wasi/wasix.rs:272:17
    |
272 |         __fds: [c_int; FD_SETSIZE as usize],
    |                 ^^^^^ not found in this scope
    |
help: consider importing one of these type aliases
    |
1   + use c_int;
    |
1   + use ffi::c_int;
    |
error[E0425]: cannot find value `FD_SETSIZE` in this scope
   --> /libc/src/wasi/wasix.rs:272:24
    |
272 |         __fds: [c_int; FD_SETSIZE as usize],
    |                        ^^^^^^^^^^ not found in this scope
    |
help: consider importing this constant through its public re-export
    |
1   + use FD_SETSIZE;
    |

I also had a minor issue running the tests, the compiler wanted me to remove unnecessary parentheses around a closure in `build.rs` so I included that to ensure the build passed in this PR.  